### PR TITLE
Skip .git/ and vendor/ unless -a is given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tryhard

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ var (
 	// main operation modes
 	list    = flag.Bool("l", false, "list positions of potential `try` candidate statements")
 	rewrite = flag.Bool("r", false, "rewrite potential `try` candidate statements to use `try`")
+	all     = flag.Bool("a", false, "also search check directories named `vendor` and `.git`")
 )
 
 var (
@@ -161,7 +162,14 @@ func processFile(filename string) error {
 }
 
 func visitFile(path string, f os.FileInfo, err error) error {
-	if err == nil && isGoFile(f) {
+	// If not -a is given, skip vendor/ and .git/ directories
+	if !*all && err == nil && f.IsDir() {
+		switch filepath.Base(path) {
+		case "vendor", ".git":
+			// Skip this directory, and all contents within it
+			return filepath.SkipDir
+		}
+	} else if err == nil && isGoFile(f) {
 		err = processFile(path)
 	}
 	// Don't complain if a file was deleted in the meantime (i.e.


### PR DESCRIPTION
Hi,

Thanks for creating the `tryhard` utility. I tried running it on a couple of my projects, and I think it will be a useful tool in the future.

For practicality, I added code that will skip the `.git/` and `vendor/` folders, unless an `-a` flag is given. This made the utility more useful, for me.

Best regards,
Alexander F. Rødseth